### PR TITLE
Fixed NPE in zookeeper.server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject zookeeper-clj "0.9.1"
+(defproject zookeeper-clj "0.9.2"
   :description "A Clojure DSL for Apache ZooKeeper"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.apache.zookeeper/zookeeper "3.3.2"]

--- a/src/zookeeper/server.clj
+++ b/src/zookeeper/server.clj
@@ -4,8 +4,9 @@
 
 (defn server-config
   ([filename]
-     (-> (ServerConfig.)
-         (.parse filename))))
+     (let [server-config (ServerConfig.)]
+       (.parse server-config filename)
+       server-config)))
 
 (defn start-server
   ([config-filename]


### PR DESCRIPTION
Hi,

first of all thank you so much for creating zookeeper-clj and Avout :-)

I've started using zookeeper-clj. During development I start Zookeeper in process and try to use zookeeper.server/start-server for that purpose, but there is a NullPointerException due to the fact that the parse method of the stateful ServerConfig object returns nil.

Best regards

Max
