### PR TITLE
Use timeout in CountdownLatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+zookeeper.out
+target
 pom.xml
+pom.xml.asc
 *jar
 /lib/
 /classes/

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject zookeeper-clj "0.9.4-timeout-fix"
+(defproject xookeeper-clj "0.1.1"
   :description "A Clojure DSL for Apache ZooKeeper"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.apache.zookeeper/zookeeper "3.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject xookeeper-clj "0.1.1"
+(defproject zookeeper-clj "0.9.5"
   :description "A Clojure DSL for Apache ZooKeeper"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.apache.zookeeper/zookeeper "3.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject zookeeper-clj "0.9.3"
+(defproject zookeeper-clj "0.9.4-timeout-fix"
   :description "A Clojure DSL for Apache ZooKeeper"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.apache.zookeeper/zookeeper "3.4.0"]

--- a/src/zookeeper.clj
+++ b/src/zookeeper.clj
@@ -22,18 +22,38 @@ Out of the box ZooKeeper provides name service, configuration, and group members
 
 ;; connection functions
 
-(defn connect
-  "Returns a ZooKeeper client."
-  ([connection-string & {:keys [timeout-msec watcher]
-                         :or {timeout-msec 5000}}]
+(defn- make-connection
+  ([]
+     (fn [connection-string timeout-msec session-watcher]
+       (ZooKeeper. connection-string timeout-msec session-watcher)))
+  ([session-id session-password]
+     (fn [connection-string timeout-msec session-watcher]
+       (ZooKeeper. connection-string timeout-msec session-watcher session-id session-password))))
+
+(defn connect-with-timer
+  "Tries to connect, Returns a ZooKeeper client unless connection times out"
+  ([connection-string connection-fn timeout-msec watcher]
      (let [latch (CountDownLatch. 1)
            session-watcher (zi/make-watcher (fn [event]
-                                           (when (= (:keeper-state event) :SyncConnected)
-                                             (.countDown latch))
-                                           (when watcher (watcher event))))
-           client (ZooKeeper. connection-string timeout-msec session-watcher)]
+                                              (when (= (:keeper-state event) :SyncConnected)
+                                                (.countDown latch))
+                                              (when watcher (watcher event))))
+           client (connection-fn connection-string timeout-msec session-watcher)]
        (.await latch timeout-msec (. TimeUnit MILLISECONDS))
        client)))
+
+(defn connect
+  "Returns a ZooKeeper client."
+  ([connection-string & {:keys [timeout-msec watcher session-id session-password]
+                         :or {timeout-msec 5000}}]
+     (if (and session-id session-password)
+       (connect-with-timer connection-string
+         (make-connection session-id session-password)
+         timeout-msec watcher)
+       (connect-with-timer connection-string
+         (make-connection)
+         timeout-msec watcher))))
+
 
 (defn close
   "Closes the connection to the ZooKeeper server."
@@ -49,6 +69,12 @@ Out of the box ZooKeeper provides name service, configuration, and group members
    :ASSOCIATING, :CONNECTED, :CLOSED, or :AUTH_FAILED"
   ([^ZooKeeper client]
      (keyword (.toString (.getState client)))))
+
+(defn session-password [^ZooKeeper client]
+  (.getSessionPasswd client))
+
+(defn session-id [^ZooKeeper client]
+  (.getSessionId client))
 
 ;; node existence function
 

--- a/src/zookeeper.clj
+++ b/src/zookeeper.clj
@@ -13,7 +13,8 @@ Out of the box ZooKeeper provides name service, configuration, and group members
   (:import (org.apache.zookeeper ZooKeeper KeeperException KeeperException$BadVersionException)
            (org.apache.zookeeper.data Stat Id ACL)
            (java.util.concurrent CountDownLatch)
-           (java.util Arrays))
+           (java.util Arrays)
+           (java.util.concurrent TimeUnit))
   (:require [clojure.string :as s]
             [zookeeper.internal :as zi]
             [zookeeper.util :as util]))
@@ -31,7 +32,7 @@ Out of the box ZooKeeper provides name service, configuration, and group members
                                              (.countDown latch))
                                            (when watcher (watcher event))))
            client (ZooKeeper. connection-string timeout-msec session-watcher)]
-       (.await latch)
+       (.await latch timeout-msec (. TimeUnit MILLISECONDS))
        client)))
 
 (defn close
@@ -512,4 +513,3 @@ Out of the box ZooKeeper provides name service, configuration, and group members
   "Creates an instance of an ACL using the digest scheme."
   ([username password & perms]
      (apply acl "digest" (str username ":" password) (or perms default-perms))))
-

--- a/src/zookeeper/internal.clj
+++ b/src/zookeeper/internal.clj
@@ -51,6 +51,7 @@
 
 (defn make-watcher
   ([handler]
+     (println "+++ making watcher from" handler)
      (reify Watcher
        (process [this event]
          (handler (event-to-map event))))))

--- a/src/zookeeper/internal.clj
+++ b/src/zookeeper/internal.clj
@@ -51,7 +51,6 @@
 
 (defn make-watcher
   ([handler]
-     (println "+++ making watcher from" handler)
      (reify Watcher
        (process [this event]
          (handler (event-to-map event))))))

--- a/test/zookeeper/test/zookeeper_test.clj
+++ b/test/zookeeper/test/zookeeper_test.clj
@@ -82,3 +82,8 @@
 
     ;; close the client
     (close client)))
+
+(deftest no-server-test
+  (let [client (connect "127.0.0.1:80" :timeout-ms 1)]
+    (is (org.apache.zookeeper.ZooKeeper$States/CONNECTING)
+        (.getState client ))))


### PR DESCRIPTION
Hi, without this change my calls to connect hang indefinitely. I have just passed the timeout-ms to the countdown latch await call.

I'm not really sure using the same val for the timeoutLatch and the zk client timeout is the right approach - happy to discuss.

Cheers
