### PR TITLE
Excludes slf4j binding from compile-time dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject zookeeper-clj "0.9.3"
   :description "A Clojure DSL for Apache ZooKeeper"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.apache.zookeeper/zookeeper "3.4.0"]
+                 [org.apache.zookeeper/zookeeper "3.4.0" :exclusions [org.slf4j/slf4j-log4j12]]
                  [log4j/log4j "1.2.17"]
                  [commons-codec "1.7"]])


### PR DESCRIPTION
The ZooKeeper library includes a dependency on `org.slf4j/slf4j-log4j12` 1.6.1. When I add `zookeeper-clj` to my dependencies and add a different SLF4J binding, I get this warning:

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/david/.m2/repository/org/slf4j/slf4j-nop/1.7.5/slf4j-nop-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/david/.m2/repository/org/slf4j/slf4j-log4j12/1.6.1/slf4j-log4j12-1.6.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.helpers.NOPLoggerFactory]
```

The web page mentioned in the warning (http://www.slf4j.org/codes.html#multiple_bindings) says that libraries should only depend on `org.slf4j/slf4j-api` and not provide a binding.

This is a problem with the upstream ZooKeeper library, but you can address it by excluding the SLF4J bindings in your dependencies. That's what this pull request does.

Note that the SLF4J web page also mentions excluding the `log4j` library, which is something added by `zookeeper-clj`. I'm not familiar enough with your library or Java logging to know what to do about `log4j`. Maybe it should be in the `provided` profile?
