### PR TITLE
Fixed create fn to return false if node already exists

### DIFF
--- a/src/zookeeper.clj
+++ b/src/zookeeper.clj
@@ -157,7 +157,7 @@ Out of the box ZooKeeper provides name service, configuration, and group members
          (.create client path data acl
                   (zi/create-modes {:persistent? persistent?, :sequential? sequential?}))
          (catch org.apache.zookeeper.KeeperException$NodeExistsException e
-           path)
+           false)
          (catch KeeperException e (throw e))))))
 
 (defn create-all
@@ -179,9 +179,9 @@ Out of the box ZooKeeper provides name service, configuration, and group members
            (let [node (str result-path "/" dir)]
              (if (exists client node)
                (recur node children)
-               (recur (if (seq children)
+               (recur (or (if (seq children)
                         (create client node :persistent? true)
-                        (apply create client node options))
+                        (apply create client node options)) node)
                       children)))
            result-path)))))
 


### PR DESCRIPTION
The doc string says `If the node already exists, create will return false.` but the implementation returned the path of the node instead.

I fixed this (so that callers of `create` can distinguish the two cases), but this is a breaking change, so if other code (like e.g. in `avout`) already depends on the "contra-documented" feature, it will break.

`create-all` is such an example which could fail due to the change in `create`'s return value, had I not also taken care of that.

With the old version of `create-all`, in case of a rare race condition where the node in question is created by another process or thread in-between the call to `(exists ... node)` and the subsequent call to `(create ... node)`,
