### PR TITLE
Update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
 (defproject zookeeper-clj "0.9.5-SNAPSHOT"
   :description "A Clojure DSL for Apache ZooKeeper"
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.apache.zookeeper/zookeeper "3.6.1"]
-                 [commons-codec "1.14"]
-                 [org.apache.curator/curator-test "5.1.0" :scope "test"]]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.apache.zookeeper/zookeeper "3.8.0"]
+                 [commons-codec "1.15"]
+                 [org.apache.curator/curator-test "5.2.1" :scope "test"]]
   :repositories {"clojars" {:sign-releases false :url "https://clojars.org/repo/"}}
   :global-vars {*warn-on-reflection* true}
   :plugins [[lein-ancient "0.6.15"]

--- a/test/zookeeper/test/zookeeper_test.clj
+++ b/test/zookeeper/test/zookeeper_test.clj
@@ -2,9 +2,11 @@
   (:use [zookeeper]
         [clojure.test])
   (:import [java.util UUID]
-           [org.apache.curator.test TestingServer]))
+           [org.apache.curator.test TestingServer]
+           [ch.qos.logback.classic Level Logger]))
 
 (defn setup-embedded-zk [f]
+  (.setLevel ^Logger (org.slf4j.LoggerFactory/getLogger (Logger/ROOT_LOGGER_NAME)) Level/ERROR)
   (let [server (TestingServer. 2181)]
     (do (f)
         (.close server))))


### PR DESCRIPTION
First of all: Thanks for this nice library!! 🙏

This PR updates the dependencies of this library. Specifically the zookeeper dependency itself, because security issues have been fixed since the version that was used before.

The new zookeeper client library causes the tests to produce lots of logging, so I added test setup to set the default log level to `error`.