### PR TITLE
Update to latest dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target*
 *#
 .#*
 .clj-kondo/.cache
+.lsp

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject zookeeper-clj "0.10.0"
+(defproject zookeeper-clj "0.11.0"
   :description "A Clojure DSL for Apache ZooKeeper"
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.apache.zookeeper/zookeeper "3.8.0"]
-                 [commons-codec "1.15"]
-                 [org.apache.curator/curator-test "5.2.1" :scope "test"]]
+                 [org.apache.zookeeper/zookeeper "3.9.1"]
+                 [commons-codec "1.16.0"]
+                 [org.apache.curator/curator-test "5.6.0" :scope "test"]]
   :repositories {"clojars" {:sign-releases false :url "https://clojars.org/repo/"}}
   :global-vars {*warn-on-reflection* true}
-  :plugins [[lein-ancient "0.6.15"]
-            [lein-cljfmt "0.6.8"]])
+  :plugins [[lein-ancient "0.7.0"]
+            [lein-cljfmt "0.9.2"]])


### PR DESCRIPTION
All deps updated. In particular, this addresses [CVE-2023-44981](https://nvd.nist.gov/vuln/detail/CVE-2023-44981) with the zookeeper dependency bump.