### PR TITLE
Update to latest dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject zookeeper-clj "0.12.0"
+(defproject zookeeper-clj "0.13.0"
   :description "A Clojure DSL for Apache ZooKeeper"
   :dependencies [[org.clojure/clojure "1.11.2"]
-                 [org.apache.zookeeper/zookeeper "3.9.2"]
-                 [commons-codec "1.16.1"]
-                 [org.apache.curator/curator-test "5.6.0" :scope "test"]]
+                 [org.apache.zookeeper/zookeeper "3.9.3"]
+                 [commons-codec "1.17.1"]
+                 [org.apache.curator/curator-test "5.7.1" :scope "test"]]
   :deploy-repositories {"clojars" {:sign-releases false :url "https://repo.clojars.org"}}
   :global-vars {*warn-on-reflection* true}
   :url "https://github.com/liebke/zookeeper-clj"


### PR DESCRIPTION
This upgrades all the deps. In particular, the newest version of zookeeper resolves BDSA-2024-0720 issue in `netty`.